### PR TITLE
Remove duplicates from the list of rendered files returned by ReplaceWithRendered

### DIFF
--- a/replace.go
+++ b/replace.go
@@ -61,15 +61,16 @@ func (r *Runner) ReplaceWithRendered(name, chart string, files []string, o Repla
 	if err != nil {
 		return nil, err
 	}
-	results := []string{}
+	writtenFiles := map[string]bool{}
 	lines := strings.Split(stdout, "\n")
 	for _, line := range lines {
 		if strings.HasPrefix(line, "wrote ") {
-			results = append(results, strings.Split(line, "wrote ")[1])
+			file := strings.Split(line, "wrote ")[1]
+			writtenFiles[file] = true
 		}
 	}
 
-	if len(results) == 0 {
+	if len(writtenFiles) == 0 {
 		return nil, fmt.Errorf("invalid state: no files rendered")
 	}
 
@@ -80,5 +81,9 @@ func (r *Runner) ReplaceWithRendered(name, chart string, files []string, o Repla
 		}
 	}
 
+	results := make([]string, 0, len(writtenFiles))
+	for f := range writtenFiles {
+		results = append(results, f)
+	}
 	return results, nil
 }


### PR DESCRIPTION
Fixes https://github.com/roboll/helmfile/issues/1279

'helm template' writes to files manifest by manifest, appending to existing files as needed:
https://github.com/helm/helm/blob/v3.2.1/pkg/action/action.go#L192-L210

When helmfile feeds the list of files as resources to load to kustomize, this can lead to an error like "may not add resource with an already registered id" if duplicates aren't removed.

Minimal example (helm 3.1.3, kustomize 3.6.1, helmfile 0.118.1)

```yaml
repositories:
  - name: stable
    url: https://kubernetes-charts.storage.googleapis.com

releases:
  - name: datadog
    namespace: datadog-system
    chart: stable/datadog
    version: 2.3.5
    values:
    - clusterAgent:
        datadog_cluster_yaml:
          foo: bar
    jsonPatches:
    - target:
        version: v1
        kind: ConfigMap
        name: datadog-cluster-agent-config
      patch:
      - op: replace
        path: "/metadata/labels/app.kubernetes.io~1version"
        value: "7"

```