### PR TITLE
fix transformers on windows platform

### DIFF
--- a/chartify.go
+++ b/chartify.go
@@ -499,7 +499,7 @@ func (r *Runner) RewriteChartToPreventDoubleRendering(tempDir, filesDir string) 
 				return fmt.Errorf("calculating relative path to %s from %s: %v", path, filesDir, err)
 			}
 
-			content := []byte(fmt.Sprintf(`{{ .Files.Get "files/%s" }}`, rel))
+			content := []byte(fmt.Sprintf(`{{ .Files.Get "files/%s" }}`, filepath.ToSlash(rel)))
 
 			f := filepath.Join(tempDir, rel)
 

--- a/patch.go
+++ b/patch.go
@@ -42,7 +42,7 @@ apiversion: ""
 resources:
 `
 	for _, f := range generatedManifestFiles {
-		f = strings.Replace(f, tempDir+"/", "", 1)
+		f = strings.Replace(f, tempDir+string(filepath.Separator), "", 1)
 		kustomizationYamlContent += `- ` + f + "\n"
 	}
 

--- a/replace.go
+++ b/replace.go
@@ -103,7 +103,7 @@ func (r *Runner) ReplaceWithRendered(name, chartName, chartPath string, o Replac
 			for _, d := range ContentDirs {
 				origDir := filepath.Join(chartPath, d)
 				newDir := filepath.Join(chartOutputDir, d)
-				file = strings.ReplaceAll(file, newDir, origDir)
+				file = strings.ReplaceAll(strings.ReplaceAll(file, "/", string(filepath.Separator)), newDir, origDir)
 			}
 
 			writtenFiles[file] = true


### PR DESCRIPTION
Fix is dedicated to enable usage of helmfile transformers on windows platform. 
All 3 fixes are related to path separators that behave different and were corrected to support linux and windows.
