### PR TITLE
deleting breaking remove of helmx.1.rendered dir

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,6 +32,6 @@ jobs:
 
         export PATH=$PATH:$(pwd)/bin
 
-        helm repo add stable https://kubernetes-charts.storage.googleapis.com
+        helm repo add stable https://charts.helm.sh/stable
 
         CGO_ENABLED=0 go test ./...

--- a/cmd/chartify/main.go
+++ b/cmd/chartify/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/variantdev/chartify"
 	"os"
+	"strings"
+
+	"github.com/variantdev/chartify"
 )
 
 type stringSlice []string
@@ -42,11 +44,22 @@ func main() {
 
 	flag.StringVar(&file, "f", "-", "The path to the input file or stdout(-)")
 	flag.StringVar(&outDir, "o", "", "The path to the output directory")
-	flag.Var(&deps, "d", "one or more \"alias=chart:verion\" to add adhoc chart dependencies")
+	flag.Var(&deps, "d", "one or more \"alias=chart:version\" to add adhoc chart dependencies")
 
 	flag.Parse()
 
-	opts.AdhocChartDependencies = deps
+	chartDeps := make([]chartify.ChartDependency, 0)
+	for _, dep := range deps {
+		sliceOfText := strings.Split(dep, "=")
+		alias := sliceOfText[0]
+		sliceOfChart := strings.Split(sliceOfText[1],":")
+		chart := sliceOfChart[0]
+		version := sliceOfChart[1]
+		a := chartify.ChartDependency {Alias: alias, Chart: chart, Version: version}
+		chartDeps = append(chartDeps, a)
+	}
+
+	opts.AdhocChartDependencies = chartDeps
 
 	c := chartify.New(chartify.UseHelm3(true), chartify.HelmBin("helm"))
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -77,7 +77,7 @@ func TestIntegration(t *testing.T) {
 			fileList: "testdata/prometheus-operator-adhoc-dep/filelist.yaml",
 			opts: ChartifyOpts{
 				ChartVersion:           "9.2.2",
-				AdhocChartDependencies: []string{"my=stable/mysql:1.6.6"},
+				AdhocChartDependencies: []ChartDependency{{"my","stable/mysql","1.6.6"}},
 			},
 		},
 		{
@@ -109,7 +109,7 @@ func TestIntegration(t *testing.T) {
 			opts: ChartifyOpts{
 				ValuesFiles:            []string{"testdata/prometheus-operator-adhoc-dep-with-strategicpatch/values.yaml"},
 				ChartVersion:           "9.2.1",
-				AdhocChartDependencies: []string{"my=stable/mysql:1.6.6"},
+				AdhocChartDependencies: []ChartDependency{{"my","stable/mysql","1.6.6"}},
 				StrategicMergePatches:  []string{"testdata/prometheus-operator-adhoc-dep-with-strategicpatch/strategicpatch.yaml"},
 			},
 		},

--- a/replace.go
+++ b/replace.go
@@ -149,10 +149,6 @@ func (r *Runner) ReplaceWithRendered(name, chartName, chartPath string, o Replac
 		return nil, fmt.Errorf("invalid state: no files rendered")
 	}
 
-	if err := os.RemoveAll(helmOutputDir); err != nil {
-		return nil, fmt.Errorf("cleaning up unnecessary files after replace: %v", err)
-	}
-
 	results := make([]string, 0, len(writtenFiles))
 	for f := range writtenFiles {
 		results = append(results, f)


### PR DESCRIPTION
Before the change when applying transformers user got following error from kustomize binary that kustomize failed and the reason was that in kustomization.yaml file were referred files inside helmx.1 directory however the directory was not existing at that point of time
```bash
tomas@tomas-ThinkPad-W550s:~/Develop/test$ helmfile template 
in ./helmfile.yaml: [exit status 1

COMMAND:
  kustomize build /tmp/chartify043502074/test --output /tmp/chartify043502074/test/all.patched.yaml

OUTPUT:
  Error: accumulating resources: accumulation err='accumulating resources from 'helmx.1.rendered/test/templates/serviceaccount.yaml': evalsymlink failure on '/tmp/chartify043502074/test/helmx.1.rendered/test/templates/serviceaccount.yaml' : lstat /tmp/chartify043502074/test/helmx.1.rendered: no such file or directory': evalsymlink failure on '/tmp/chartify043502074/test/helmx.1.rendered/test/templates/serviceaccount.yaml' : lstat /tmp/chartify043502074/test/helmx.1.rendered: no such file or directory]
```

solution was to remove the os.RemoveAll(helmOutputDir) poiting to helmx.1 dir 

After removing and local testing the transformers works again. 

Please consider to apply and include into helmfile as updated version of go dependency