### PR TITLE
Fix #18: Better yaml doc separator

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
         curl -Ls "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
         mv kustomize ./bin/
 
-        export PATH=$PATH:$(pwd)/bin
+        export PATH=$(pwd -P)/bin:$PATH
 
         helm repo add stable https://charts.helm.sh/stable
 

--- a/patch.go
+++ b/patch.go
@@ -193,7 +193,7 @@ resources:
 		}
 
 		if i := bytes.Index(d, []byte("\n---\n")); i >= 0 {
-			return i + 4, d[0:i], nil
+			return i + 5, d[0:i], nil
 		}
 
 		// "SplitFunc can return (0, nil, nil) to signal the Scanner to read more data into the slice and try again with a longer slice starting at the same point in the input."

--- a/patch.go
+++ b/patch.go
@@ -192,7 +192,7 @@ resources:
 			return len(d), d, nil
 		}
 
-		if i := bytes.Index(d, []byte("---\n")); i >= 0 {
+		if i := bytes.Index(d, []byte("\n---\n")); i >= 0 {
 			return i + 4, d[0:i], nil
 		}
 

--- a/patch.go
+++ b/patch.go
@@ -193,7 +193,7 @@ resources:
 		}
 
 		if i := bytes.Index(d, []byte("\n---\n")); i >= 0 {
-			return i + 5, d[0:i], nil
+			return i + 5, d[0:i+1], nil
 		}
 
 		// "SplitFunc can return (0, nil, nil) to signal the Scanner to read more data into the slice and try again with a longer slice starting at the same point in the input."

--- a/testdata/raw-manifests/input/configmap.yaml
+++ b/testdata/raw-manifests/input/configmap.yaml
@@ -8,3 +8,14 @@ data:
     -----BEGIN CERTIFICATE-----
     FOO
     -----END CERTIFICATE-----
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: myconfig2
+data:
+  foo: bar
+  bar: |
+    -----BEGIN CERTIFICATE-----
+    FOO
+    -----END CERTIFICATE-----

--- a/testdata/raw-manifests/input/configmap.yaml
+++ b/testdata/raw-manifests/input/configmap.yaml
@@ -4,3 +4,7 @@ metadata:
   name: myconfig
 data:
   foo: bar
+  bar: |
+    -----BEGIN CERTIFICATE-----
+    FOO
+    -----END CERTIFICATE-----

--- a/testdata/raw-manifests/input/foo/configmap.2.yaml
+++ b/testdata/raw-manifests/input/foo/configmap.2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: myconfig
 data:
   foo: baz
-  bar: |
+  baz: |
     -----BEGIN CERTIFICATE-----
     FOO
     -----END CERTIFICATE-----

--- a/testdata/raw-manifests/input/foo/configmap.2.yaml
+++ b/testdata/raw-manifests/input/foo/configmap.2.yaml
@@ -4,7 +4,6 @@ metadata:
   name: myconfig
 data:
   foo: baz
-  # See also https://github.com/variantdev/chartify/issues/18
   bar: |
     -----BEGIN CERTIFICATE-----
     FOO

--- a/testdata/raw-manifests/input/foo/configmap.2.yaml
+++ b/testdata/raw-manifests/input/foo/configmap.2.yaml
@@ -4,3 +4,8 @@ metadata:
   name: myconfig
 data:
   foo: baz
+  # See also https://github.com/variantdev/chartify/issues/18
+  bar: |
+    -----BEGIN CERTIFICATE-----
+    FOO
+    -----END CERTIFICATE-----

--- a/testdata/raw-manifests/output/files/templates/configmap.yaml
+++ b/testdata/raw-manifests/output/files/templates/configmap.yaml
@@ -6,3 +6,7 @@ metadata:
   namespace: foo
 data:
   foo: bar
+  bar: |
+    -----BEGIN CERTIFICATE-----
+    FOO
+    -----END CERTIFICATE-----

--- a/testdata/raw-manifests/output/files/templates/configmap.yaml
+++ b/testdata/raw-manifests/output/files/templates/configmap.yaml
@@ -10,3 +10,16 @@ data:
     -----BEGIN CERTIFICATE-----
     FOO
     -----END CERTIFICATE-----
+---
+# Source: input/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: myconfig2
+  namespace: foo
+data:
+  foo: bar
+  bar: |
+    -----BEGIN CERTIFICATE-----
+    FOO
+    -----END CERTIFICATE-----

--- a/testdata/raw-manifests/output/files/templates/foo/configmap.2.yaml
+++ b/testdata/raw-manifests/output/files/templates/foo/configmap.2.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: foo
 data:
   foo: baz
-  bar: |
+  baz: |
     -----BEGIN CERTIFICATE-----
     FOO
     -----END CERTIFICATE-----

--- a/testdata/raw-manifests/output/files/templates/foo/configmap.2.yaml
+++ b/testdata/raw-manifests/output/files/templates/foo/configmap.2.yaml
@@ -6,3 +6,7 @@ metadata:
   namespace: foo
 data:
   foo: baz
+  bar: |
+    -----BEGIN CERTIFICATE-----
+    FOO
+    -----END CERTIFICATE-----


### PR DESCRIPTION
This PR fixes https://github.com/variantdev/chartify/issues/18