### PR TITLE
Fix adhoc chart dependencies not working for some charts

### DIFF
--- a/cmd/chartify/main.go
+++ b/cmd/chartify/main.go
@@ -3,8 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/variantdev/chartify"
 	"os"
+
+	"github.com/variantdev/chartify"
 )
 
 type stringSlice []string
@@ -46,7 +47,7 @@ func main() {
 
 	flag.Parse()
 
-	opts.AdhocChartDependencies = deps
+	opts.DeprecatedAdhocChartDependencies = deps
 
 	c := chartify.New(chartify.UseHelm3(true), chartify.HelmBin("helm"))
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -2,8 +2,6 @@ package chartify
 
 import (
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v3"
 	"io"
 	"io/ioutil"
 	"os"
@@ -11,6 +9,9 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
 )
 
 func errWithFiles(err error, tmpDir string) error {
@@ -77,7 +78,7 @@ func TestIntegration(t *testing.T) {
 			fileList: "testdata/prometheus-operator-adhoc-dep/filelist.yaml",
 			opts: ChartifyOpts{
 				ChartVersion:           "9.2.2",
-				AdhocChartDependencies: []string{"my=stable/mysql:1.6.6"},
+				AdhocChartDependencies: []ChartDependency{{Alias: "my", Chart: "stable/mysql", Version: "1.6.6"}},
 			},
 		},
 		{
@@ -109,7 +110,7 @@ func TestIntegration(t *testing.T) {
 			opts: ChartifyOpts{
 				ValuesFiles:            []string{"testdata/prometheus-operator-adhoc-dep-with-strategicpatch/values.yaml"},
 				ChartVersion:           "9.2.1",
-				AdhocChartDependencies: []string{"my=stable/mysql:1.6.6"},
+				AdhocChartDependencies: []ChartDependency{{Alias: "my", Chart: "stable/mysql", Version: "1.6.6"}},
 				StrategicMergePatches:  []string{"testdata/prometheus-operator-adhoc-dep-with-strategicpatch/strategicpatch.yaml"},
 			},
 		},


### PR DESCRIPTION
Some charts like gitlab/gitlab seem to have dependencies to its own sibling charts:

https://gitlab.com/gitlab-org/charts/gitlab/-/blob/master/requirements.yaml#L2-9

Apparently, chartify fails for such chart because how we handled adhoc dependencies.

The problem was that chartify was unnecessarily rerunning dependency downloads on the standard (non adhoc) chart dependencies declared in the chart.yaml and requirements.yaml, even though helm-fetch command that ran beforehand has already downloaded all of them.

This change fixes the issue by removing the already-downloaded chart dependencies out of Chart.yaml and requirements.yaml in case it is a remote chart. This way, it does not try to rerun dependency downloads hence it wont suffer from dependencies to sibling charts.

Ref https://github.com/roboll/helmfile/issues/2097