### PR TITLE
Fix the lock-file-out-of-sync error with local chart + adhoc deps

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         mkdir ./bin
 
-        HELM_VERSION=v3.2.1
+        HELM_VERSION=v3.8.1
         HELM_LOCATION="https://get.helm.sh"
         HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
         curl -LO ${HELM_LOCATION}/${HELM_FILENAME} && \

--- a/replace.go
+++ b/replace.go
@@ -246,7 +246,7 @@ func (r *Runner) ReplaceWithRendered(name, chartName, chartPath string, o Replac
 	}
 
 	// We need to remove dangling Chart.lock and requirements.lock too, as the corresponding dependencies
-	// are already deleted out fro Chart.yaml/requirements.yaml above.
+	// are already deleted out of Chart.yaml/requirements.yaml as above.
 	// Otherwise, you may end up with issues like:
 	// https://github.com/roboll/helmfile/issues/2074#issuecomment-1068335836
 

--- a/testdata/integration/testcases/local_chart_with_adhoc_dependency/want
+++ b/testdata/integration/testcases/local_chart_with_adhoc_dependency/want
@@ -1,0 +1,100 @@
+---
+# Source: db/templates/charts/log/templates/deployment.yaml
+# Source: db/charts/log/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp-log
+  labels:
+    helm.sh/chart: log-0.1.0
+    app.kubernetes.io/name: log
+    app.kubernetes.io/instance: myapp
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: log
+      app.kubernetes.io/instance: myapp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: log
+        app.kubernetes.io/instance: myapp
+    spec:
+      containers:
+        - name: log
+          image: "nginx:1.16.0"
+---
+# Source: db/templates/deployment.yaml
+# Source: db/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp-db
+  labels:
+    helm.sh/chart: db-0.1.0
+    app.kubernetes.io/name: db
+    app.kubernetes.io/instance: myapp
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: db
+      app.kubernetes.io/instance: myapp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: db
+        app.kubernetes.io/instance: myapp
+    spec:
+      containers:
+        - name: db
+          image: "nginx:1.16.0"
+---
+# Source: db/templates/charts/log/templates/tests/test-connection.yaml
+# Source: db/charts/log/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "myapp-log-test-connection"
+  labels:
+    helm.sh/chart: log-0.1.0
+    app.kubernetes.io/name: log
+    app.kubernetes.io/instance: myapp
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['myapp-log:80']
+  restartPolicy: Never
+---
+# Source: db/templates/tests/test-connection.yaml
+# Source: db/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "myapp-db-test-connection"
+  labels:
+    helm.sh/chart: db-0.1.0
+    app.kubernetes.io/name: db
+    app.kubernetes.io/instance: myapp
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['myapp-db:80']
+  restartPolicy: Never


### PR DESCRIPTION
It turns out we only removed unnecessary dependencies from Chart.yaml and requirements.yaml, and not from Chart.lock and requirements.lock. These dangling lock files seem to result in the mentioned error.

Since this change, any remote or local chart that went through the chartify process will have all the lock files omitted, so that the error is gone. This is fine because all the original and adhoc dependencies are already included in the chartify output chart, due to that it is generated by `helm template`ing the original chart with various tweaks.

Ref https://github.com/roboll/helmfile/issues/2074#issuecomment-1068335836