### PR TITLE
Add support for --kube-version reintroduced in Helm 3

### DIFF
--- a/chartify.go
+++ b/chartify.go
@@ -96,6 +96,14 @@ type ChartifyOpts struct {
 	// even if you aren't trying to install the generated chart onto the cluster.
 	Validate bool
 
+	// KubeVersion specifies the Kubernetes version used for Capabilities.KubeVersion
+	// when running `helm template` to produce the temporary chart to apply various customizations.
+	// If the upstream command that calls chartify was going to pass `kube-version` while rendering the original chart,
+	// you must also pass the same value to this field.
+	// Otherwise the temporary chart rendered by chartify lacks `kube-version` at helm-template time
+	// and it my produce output unexpected to you.
+	KubeVersion string
+
 	// ApiVersions is a string of kubernetes APIVersions and passed to helm template via --api-versions
 	// It is required if your chart contains any template that relies on Capabilities.APIVersion for rendering
 	// resources depending on the API resources and versions available in a target cluster.
@@ -369,6 +377,7 @@ func (r *Runner) Chartify(release, dirOrChart string, opts ...ChartifyOption) (s
 		ChartVersion: u.ChartVersion,
 		IncludeCRDs:  u.IncludeCRDs,
 		Validate:     u.Validate,
+		KubeVersion:  u.KubeVersion,
 		ApiVersions:  u.ApiVersions,
 
 		WorkaroundOutputDirIssue: u.WorkaroundOutputDirIssue,

--- a/integration_test.go
+++ b/integration_test.go
@@ -96,6 +96,21 @@ func TestIntegration(t *testing.T) {
 		},
 	})
 
+	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestIntegration/kube_version_and_api_versions$ ./
+	runTest(t, integrationTestCase{
+		description: "kube_version_and_api_versions",
+		release:     "vers1",
+		chart:       repo + "/vers",
+		opts: ChartifyOpts{
+			KubeVersion: "1.23.0",
+			ApiVersions: []string{
+				"foo/v1alpha1",
+				"bar/v1beta1",
+				"baz/v1",
+			},
+		},
+	})
+
 	//
 	// Local Chart
 	//
@@ -163,7 +178,6 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 func startServer(t *testing.T, repo string) {

--- a/replace.go
+++ b/replace.go
@@ -40,6 +40,14 @@ type ReplaceWithRenderedOpts struct {
 	// even if you aren't trying to install the generated chart onto the cluster.
 	Validate bool
 
+	// KubeVersion specifies the Kubernetes version used for Capabilities.KubeVersion
+	// when running `helm template` to produce the temporary chart to apply various customizations.
+	// If the upstream command that calls chartify was going to pass `kube-version` while rendering the original chart,
+	// you must also pass the same value to this field.
+	// Otherwise the temporary chart rendered by chartify lacks `kube-version` at helm-template time
+	// and it my produce output unexpected to you.
+	KubeVersion string
+
 	// ApiVersions is a string of kubernetes APIVersions and passed to helm template via --api-versions
 	// It is required if your chart contains any template that relies on Capabilities.APIVersion for rendering
 	// resources depending on the API resources and versions available in a target cluster.
@@ -70,6 +78,9 @@ func (r *Runner) ReplaceWithRendered(name, chartName, chartPath string, o Replac
 	additionalFlags += createFlagChain("f", o.ValuesFiles)
 	if o.Namespace != "" {
 		additionalFlags += createFlagChain("namespace", []string{o.Namespace})
+	}
+	if o.KubeVersion != "" {
+		additionalFlags += createFlagChain("kube-version", []string{o.KubeVersion})
 	}
 	additionalFlags += createFlagChain("api-versions", o.ApiVersions)
 

--- a/tempdir_test.go
+++ b/tempdir_test.go
@@ -35,21 +35,21 @@ func TestGenerateID(t *testing.T) {
 		release: "foo",
 		chart:   "incubator/raw",
 		opts:    ChartifyOpts{},
-		want:    "foo-57bddf47cd",
+		want:    "foo-6965b8c5cf",
 	})
 
 	run(testcase{
 		release: "foo",
 		chart:   "stable/envoy",
 		opts:    ChartifyOpts{},
-		want:    "foo-6486dd89f9",
+		want:    "foo-5cf848dbc6",
 	})
 
 	run(testcase{
 		release: "bar",
 		chart:   "incubator/raw",
 		opts:    ChartifyOpts{},
-		want:    "bar-6b874894dc",
+		want:    "bar-59bc7db54d",
 	})
 
 	run(testcase{
@@ -57,7 +57,7 @@ func TestGenerateID(t *testing.T) {
 		opts: ChartifyOpts{
 			Namespace: "myns",
 		},
-		want: "myns-foo-66cd978d59",
+		want: "myns-foo-c4857944",
 	})
 
 	for id, n := range ids {

--- a/testdata/charts/vers/.helmignore
+++ b/testdata/charts/vers/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/testdata/charts/vers/Chart.yaml
+++ b/testdata/charts/vers/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: vers
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/testdata/charts/vers/templates/NOTES.txt
+++ b/testdata/charts/vers/templates/NOTES.txt
@@ -1,0 +1,1 @@
+NOTE OF DB CHART

--- a/testdata/charts/vers/templates/configmap.yaml
+++ b/testdata/charts/vers/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: core/v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-vers
+spec:
+  kubeVersion: {{ .Capabilities.KubeVersion }}
+  {{ range $i, $v := .Capabilities.APIVersions -}}
+  apiVersion{{ $i }}: {{ $v }}
+  {{ end -}}

--- a/testdata/charts/vers/values.yaml
+++ b/testdata/charts/vers/values.yaml
@@ -1,0 +1,83 @@
+# Default values for db.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+      - path: /
+        backend:
+          serviceName: chart-example.local
+          servicePort: 80
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/testdata/integration/testcases/kube_version_and_api_versions/want
+++ b/testdata/integration/testcases/kube_version_and_api_versions/want
@@ -1,0 +1,59 @@
+---
+# Source: vers/templates/configmap.yaml
+# Source: vers/templates/configmap.yaml
+apiVersion: core/v1
+kind: ConfigMap
+metadata:
+  name: vers1-vers
+spec:
+  kubeVersion: v1.23.0
+  apiVersion0: v1
+  apiVersion1: admissionregistration.k8s.io/v1
+  apiVersion2: admissionregistration.k8s.io/v1beta1
+  apiVersion3: internal.apiserver.k8s.io/v1alpha1
+  apiVersion4: apps/v1
+  apiVersion5: apps/v1beta1
+  apiVersion6: apps/v1beta2
+  apiVersion7: authentication.k8s.io/v1
+  apiVersion8: authentication.k8s.io/v1beta1
+  apiVersion9: authorization.k8s.io/v1
+  apiVersion10: authorization.k8s.io/v1beta1
+  apiVersion11: autoscaling/v1
+  apiVersion12: autoscaling/v2
+  apiVersion13: autoscaling/v2beta1
+  apiVersion14: autoscaling/v2beta2
+  apiVersion15: batch/v1
+  apiVersion16: batch/v1beta1
+  apiVersion17: certificates.k8s.io/v1
+  apiVersion18: certificates.k8s.io/v1beta1
+  apiVersion19: coordination.k8s.io/v1beta1
+  apiVersion20: coordination.k8s.io/v1
+  apiVersion21: discovery.k8s.io/v1
+  apiVersion22: discovery.k8s.io/v1beta1
+  apiVersion23: events.k8s.io/v1
+  apiVersion24: events.k8s.io/v1beta1
+  apiVersion25: extensions/v1beta1
+  apiVersion26: flowcontrol.apiserver.k8s.io/v1alpha1
+  apiVersion27: flowcontrol.apiserver.k8s.io/v1beta1
+  apiVersion28: flowcontrol.apiserver.k8s.io/v1beta2
+  apiVersion29: networking.k8s.io/v1
+  apiVersion30: networking.k8s.io/v1beta1
+  apiVersion31: node.k8s.io/v1
+  apiVersion32: node.k8s.io/v1alpha1
+  apiVersion33: node.k8s.io/v1beta1
+  apiVersion34: policy/v1
+  apiVersion35: policy/v1beta1
+  apiVersion36: rbac.authorization.k8s.io/v1
+  apiVersion37: rbac.authorization.k8s.io/v1beta1
+  apiVersion38: rbac.authorization.k8s.io/v1alpha1
+  apiVersion39: scheduling.k8s.io/v1alpha1
+  apiVersion40: scheduling.k8s.io/v1beta1
+  apiVersion41: scheduling.k8s.io/v1
+  apiVersion42: storage.k8s.io/v1beta1
+  apiVersion43: storage.k8s.io/v1
+  apiVersion44: storage.k8s.io/v1alpha1
+  apiVersion45: apiextensions.k8s.io/v1beta1
+  apiVersion46: apiextensions.k8s.io/v1
+  apiVersion47: foo/v1alpha1
+  apiVersion48: bar/v1beta1
+  apiVersion49: baz/v1


### PR DESCRIPTION
Helm 3 recently re-introduced `kube-version` to `helm template`. This adds support for that.