### PR TITLE
Fix kustomize patch failure due to missing helmx.1.rendered dir when the chart name ends with dot or slash

### DIFF
--- a/chartify.go
+++ b/chartify.go
@@ -291,7 +291,7 @@ func (r *Runner) Chartify(release, dirOrChart string, opts ...ChartifyOption) (s
 		}
 	}
 
-	chartName := filepath.Base(dirOrChart)
+	chartName := filepath.Base(filepath.Clean(dirOrChart))
 	if !isChart {
 		ver := u.ChartVersion
 		if u.ChartVersion == "" {

--- a/integration_test.go
+++ b/integration_test.go
@@ -32,7 +32,7 @@ func TestIntegration(t *testing.T) {
 
 	startServer(t, repo)
 
-	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestFramework/adhoc_dependency_condition$ ./
+	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestIntegration/adhoc_dependency_condition$ ./
 	runTest(t, integrationTestCase{
 		description: "adhoc dependency condition",
 		release:     "myapp",
@@ -51,7 +51,7 @@ func TestIntegration(t *testing.T) {
 		},
 	})
 
-	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestFramework/adhoc_dependency_condition_disabled$ ./
+	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestIntegration/adhoc_dependency_condition_disabled$ ./
 	runTest(t, integrationTestCase{
 		description: "adhoc dependency condition disabled",
 		release:     "myapp",
@@ -70,7 +70,7 @@ func TestIntegration(t *testing.T) {
 		},
 	})
 
-	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestFramework/adhoc_dependency_condition_default$ ./
+	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestIntegration/adhoc_dependency_condition_default$ ./
 	runTest(t, integrationTestCase{
 		description: "adhoc dependency condition default",
 		release:     "myapp",
@@ -86,7 +86,7 @@ func TestIntegration(t *testing.T) {
 		},
 	})
 
-	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestFramework/force_namespace$ ./
+	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestIntegration/force_namespace$ ./
 	runTest(t, integrationTestCase{
 		description: "force namespace",
 		release:     "myapp",
@@ -115,7 +115,7 @@ func TestIntegration(t *testing.T) {
 	// Local Chart
 	//
 
-	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestFramework/local_chart_with_adhoc_dependency$ ./
+	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestIntegration/local_chart_with_adhoc_dependency$ ./
 	runTest(t, integrationTestCase{
 		description: "local chart with adhoc dependency",
 		release:     "myapp",
@@ -138,7 +138,7 @@ func TestIntegration(t *testing.T) {
 	// Kubernets Manifests
 	//
 
-	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestFramework/kube_manifest_with_adhoc_dep$ ./
+	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestIntegration/kube_manifest_with_adhoc_dep$ ./
 	runTest(t, integrationTestCase{
 		description: "kube_manifest_with_adhoc_dep",
 		release:     "myapp",
@@ -157,7 +157,7 @@ func TestIntegration(t *testing.T) {
 		},
 	})
 
-	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestFramework/kube_manifest_with_patch$ ./
+	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestIntegration/kube_manifest_with_patch$ ./
 	runTest(t, integrationTestCase{
 		description: "kube_manifest_with_patch",
 		release:     "myapp",

--- a/integration_test.go
+++ b/integration_test.go
@@ -134,6 +134,52 @@ func TestIntegration(t *testing.T) {
 		},
 	})
 
+	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestIntegration/local_chart_with_slash_at_the_end$ ./
+	// Related to https://github.com/variantdev/chartify/pull/13
+	runTest(t, integrationTestCase{
+		description: "local chart with slash at the end",
+		release:     "myapp",
+		chart:       "./testdata/charts/db/./",
+		opts: ChartifyOpts{
+			AdhocChartDependencies: []ChartDependency{
+				{
+					Alias:   "log",
+					Chart:   repo + "/log",
+					Version: "0.1.0",
+				},
+			},
+			StrategicMergePatches: []string{
+				"./testdata/chart_patch/deploy.db.strategic.yaml",
+			},
+			SetFlags: []string{
+				"--set", "log.enabled=true",
+			},
+		},
+	})
+
+	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestIntegration/local_chart_with_dot_at_the_end$ ./
+	// Related to https://github.com/variantdev/chartify/pull/13
+	runTest(t, integrationTestCase{
+		description: "local chart with dot at the end",
+		release:     "myapp",
+		chart:       "./testdata/charts/db/./.",
+		opts: ChartifyOpts{
+			AdhocChartDependencies: []ChartDependency{
+				{
+					Alias:   "log",
+					Chart:   repo + "/log",
+					Version: "0.1.0",
+				},
+			},
+			StrategicMergePatches: []string{
+				"./testdata/chart_patch/deploy.db.strategic.yaml",
+			},
+			SetFlags: []string{
+				"--set", "log.enabled=true",
+			},
+		},
+	})
+
 	//
 	// Kubernets Manifests
 	//

--- a/testdata/chart_patch/deploy.db.strategic.yaml
+++ b/testdata/chart_patch/deploy.db.strategic.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp-db
+spec:
+  replicas: 2

--- a/testdata/integration/testcases/local_chart_with_dot_at_the_end/want
+++ b/testdata/integration/testcases/local_chart_with_dot_at_the_end/want
@@ -1,0 +1,100 @@
+---
+# Source: db/templates/patched_resources.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: myapp
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: db
+    app.kubernetes.io/version: 1.16.0
+    helm.sh/chart: db-0.1.0
+  name: myapp-db
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: myapp
+      app.kubernetes.io/name: db
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: myapp
+        app.kubernetes.io/name: db
+    spec:
+      containers:
+      - image: nginx:1.16.0
+        name: db
+---
+# Source: db/templates/patched_resources.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: myapp
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: log
+    app.kubernetes.io/version: 1.16.0
+    helm.sh/chart: log-0.1.0
+  name: myapp-log
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: myapp
+      app.kubernetes.io/name: log
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: myapp
+        app.kubernetes.io/name: log
+    spec:
+      containers:
+      - image: nginx:1.16.0
+        name: log
+---
+# Source: db/templates/patched_resources.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    helm.sh/hook: test
+  labels:
+    app.kubernetes.io/instance: myapp
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: db
+    app.kubernetes.io/version: 1.16.0
+    helm.sh/chart: db-0.1.0
+  name: myapp-db-test-connection
+spec:
+  containers:
+  - args:
+    - myapp-db:80
+    command:
+    - wget
+    image: busybox
+    name: wget
+  restartPolicy: Never
+---
+# Source: db/templates/patched_resources.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    helm.sh/hook: test
+  labels:
+    app.kubernetes.io/instance: myapp
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: log
+    app.kubernetes.io/version: 1.16.0
+    helm.sh/chart: log-0.1.0
+  name: myapp-log-test-connection
+spec:
+  containers:
+  - args:
+    - myapp-log:80
+    command:
+    - wget
+    image: busybox
+    name: wget
+  restartPolicy: Never

--- a/testdata/integration/testcases/local_chart_with_slash_at_the_end/want
+++ b/testdata/integration/testcases/local_chart_with_slash_at_the_end/want
@@ -1,0 +1,100 @@
+---
+# Source: db/templates/patched_resources.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: myapp
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: db
+    app.kubernetes.io/version: 1.16.0
+    helm.sh/chart: db-0.1.0
+  name: myapp-db
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: myapp
+      app.kubernetes.io/name: db
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: myapp
+        app.kubernetes.io/name: db
+    spec:
+      containers:
+      - image: nginx:1.16.0
+        name: db
+---
+# Source: db/templates/patched_resources.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: myapp
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: log
+    app.kubernetes.io/version: 1.16.0
+    helm.sh/chart: log-0.1.0
+  name: myapp-log
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: myapp
+      app.kubernetes.io/name: log
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: myapp
+        app.kubernetes.io/name: log
+    spec:
+      containers:
+      - image: nginx:1.16.0
+        name: log
+---
+# Source: db/templates/patched_resources.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    helm.sh/hook: test
+  labels:
+    app.kubernetes.io/instance: myapp
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: db
+    app.kubernetes.io/version: 1.16.0
+    helm.sh/chart: db-0.1.0
+  name: myapp-db-test-connection
+spec:
+  containers:
+  - args:
+    - myapp-db:80
+    command:
+    - wget
+    image: busybox
+    name: wget
+  restartPolicy: Never
+---
+# Source: db/templates/patched_resources.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    helm.sh/hook: test
+  labels:
+    app.kubernetes.io/instance: myapp
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: log
+    app.kubernetes.io/version: 1.16.0
+    helm.sh/chart: log-0.1.0
+  name: myapp-log-test-connection
+spec:
+  containers:
+  - args:
+    - myapp-log:80
+    command:
+    - wget
+    image: busybox
+    name: wget
+  restartPolicy: Never


### PR DESCRIPTION
Ref https://github.com/variantdev/chartify/pull/13
