### PR TITLE
feat: add OCI registry support for adhoc dependencies

### DIFF
--- a/chartify.go
+++ b/chartify.go
@@ -10,6 +10,7 @@ import (
 	"text/template"
 
 	"github.com/otiai10/copy"
+	"helm.sh/helm/v3/pkg/registry"
 )
 
 var (
@@ -482,6 +483,11 @@ func (r *Runner) ReadAdhocDependencies(u *ChartifyOpts) ([]Dependency, error) {
 		if isLocalChart {
 			name = filepath.Base(d.Chart)
 			repoUrl = fmt.Sprintf("file://%s", d.Chart)
+		} else if registry.IsOCI(d.Chart) {
+			name = filepath.Base(d.Chart)
+			// Trim trailing slash to avoid invalid repository error due to duplicate slash in oci registry url
+			// while running helm dependency up
+			repoUrl = strings.TrimSuffix(d.Chart, "/"+name)
 		} else {
 			repoAndChart := strings.Split(d.Chart, "/")
 			repo := repoAndChart[0]

--- a/chartify_test.go
+++ b/chartify_test.go
@@ -1,0 +1,74 @@
+package chartify
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestReadAdhocDependencies(t *testing.T) {
+	type testcase struct {
+		opts ChartifyOpts
+		want []Dependency
+	}
+
+	helm := "helm"
+	if h := os.Getenv("HELM_BIN"); h != "" {
+		helm = h
+	}
+	runner := New(HelmBin(helm))
+
+	setupHelmConfig(t)
+	repo := "myrepo"
+	startServer(t, repo)
+
+	run := func(tc testcase) {
+		t.Helper()
+
+		got, err := runner.ReadAdhocDependencies(&tc.opts)
+		if err != nil {
+			t.Fatalf("uenxpected error: %v", err)
+		}
+
+		if d := cmp.Diff(tc.want, got); d != "" {
+			t.Fatalf("unexpected result: want (-), got (+):\n%s", d)
+		}
+	}
+
+	run(testcase{
+		opts: ChartifyOpts{
+			AdhocChartDependencies: []ChartDependency{
+				{
+					Chart: "./testdata/charts/db",
+				},
+			},
+		},
+		want: []Dependency{
+			{
+				Repository: "file://./testdata/charts/db",
+				Name:       "db",
+				Condition:  "db.enabled",
+			},
+		},
+	})
+
+	run(testcase{
+		opts: ChartifyOpts{
+			AdhocChartDependencies: []ChartDependency{
+				{
+					Chart:   "myrepo/db",
+					Version: "0.1.0",
+				},
+			},
+		},
+		want: []Dependency{
+			{
+				Repository: "http://localhost:18080/",
+				Name:       "db",
+				Version:    "0.1.0",
+				Condition:  "db.enabled",
+			},
+		},
+	})
+}

--- a/chartify_test.go
+++ b/chartify_test.go
@@ -71,4 +71,23 @@ func TestReadAdhocDependencies(t *testing.T) {
 			},
 		},
 	})
+
+	run(testcase{
+		opts: ChartifyOpts{
+			AdhocChartDependencies: []ChartDependency{
+				{
+					Chart:   "oci://r.example.com/incubator/raw",
+					Version: "0.1.0",
+				},
+			},
+		},
+		want: []Dependency{
+			{
+				Repository: "oci://r.example.com/incubator",
+				Name:       "raw",
+				Version:    "0.1.0",
+				Condition:  "raw.enabled",
+			},
+		},
+	})
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -21,15 +21,9 @@ func TestIntegration(t *testing.T) {
 		helm = h
 	}
 
+	setupHelmConfig(t)
+
 	repo := "myrepo"
-
-	tempDir := filepath.Join(t.TempDir(), "helm")
-	helmCacheHome := filepath.Join(tempDir, "cache")
-	helmConfigHone := filepath.Join(tempDir, "config")
-
-	os.Setenv("HELM_CACHE_HOME", helmCacheHome)
-	os.Setenv("HELM_CONFIG_HOME", helmConfigHone)
-
 	startServer(t, repo)
 
 	// SAVE_SNAPSHOT=1 go1.17 test -run ^TestIntegration/adhoc_dependency_condition$ ./
@@ -272,6 +266,15 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 	})
+}
+
+func setupHelmConfig(t *testing.T) {
+	tempDir := filepath.Join(t.TempDir(), "helm")
+	helmCacheHome := filepath.Join(tempDir, "cache")
+	helmConfigHone := filepath.Join(tempDir, "config")
+
+	os.Setenv("HELM_CACHE_HOME", helmCacheHome)
+	os.Setenv("HELM_CONFIG_HOME", helmConfigHone)
 }
 
 func startServer(t *testing.T, repo string) {


### PR DESCRIPTION
It seems that [helmfile](https://github.com/helmfile/helmfile) doesn't support Helm chart hosted on OCI registry as adhoc dependencies.

helmfile.yaml:

```yaml
releases:
- name: nginx
  namespace: default
  chart: oci://asia-docker.pkg.dev/gcp-sample/helm-repo/nginx
  version: 0.1.0
  values:
  - raw:
      resources:
      - apiVersion: v1
        kind: ConfigMap
        metadata:
          name: extra-env
        data:
          FOO: bar
  dependencies:
  # same functionality as incubator/raw
  # https://github.com/helm/charts/tree/master/incubator/raw
  - chart: oci://asia-docker.pkg.dev/gcp-sample/helm-repo/raw
    version: 0.1.0
```

I run into the problem while running `helmfile template` and got the following error:

```sh
❯ helmfile version
helmfile version v0.144.0

❯ helm repo list
NAME      	URL
bitnami   	https://charts.bitnami.com/bitnami

❯ helmfile --file test/oci/helmfile.yaml template
in test/oci/helmfile.yaml: [failed reading adhoc dependencies: unexpected format of `helm repo list` at line 2 "" in:
NAME      	URL
bitnami   	https://charts.bitnami.com/bitnami
]
```

That error originated from [chartify.go#L502](https://github.com/variantdev/chartify/blob/v0.9.5/chartify.go#L502) and chartify checked that the repository already registered or not by using search API (`helm repo list`).
However, OCI registry doesn't support search API at the moment. (See https://github.com/helm/helm/issues/9983)

This PR contains three commits:

1. Add unit test to verify existing functionalities for ReadAdhocDependencies function
1. Add failing test for OCI registry support
1. Add logic to skip `helm repo list` when having OCI registry prefix on adhoc dependency name
